### PR TITLE
Remove the need to require 'backbone.marionette.handlebars' in all views

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ define([
 
 ```
 
+### Configuring globally with requirejs.config()
+
+You can optionally configure Backbone.Marionette.Handlebars to be loaded before all template
+views, which removes the need to depend on it in every single view. This ensures that the plugin
+can augment default Marionette templating behavior before any templates are required. Add the plugin
+to your requirejs.config().
+
+```javascript
+deps: [ "backbone.marionette.handlebars" ]
+```
+
+
 Please be aware of that the backbone.marionette.js file should be aliased
 as 'backbone.marionette' in the paths config for your require ecosystem.
 (Backbone.Marionette.Handlebars expects it to be referenced like this, when it requires it as
@@ -140,9 +152,15 @@ var MyView = Backbone.Marionette.ItemView.extend({
 ```
 
 Please be aware of that the backbone.marionette.js file should be aliased
-as 'backbone.marionette' in the paths config for your require ecosystem.
-(Backbone.Marionette.Handlebars expects it to be referenced like this, when it requires it as
-a dependency) 
+as 'backbone.marionette' in the [paths config](http://requirejs.org/docs/api.html#config-paths) 
+for your require ecosystem. (Backbone.Marionette.Handlebars expects it to be referenced like this,
+when it requires it as a dependency)
+
+```javascript
+paths: {
+    'backbone.marionette' : 'vendor/backbone.marionette'
+}
+```
 
 ## Support
 

--- a/backbone.marionette.handlebars.js
+++ b/backbone.marionette.handlebars.js
@@ -31,9 +31,9 @@ IN THE SOFTWARE.*/
         // only CommonJS-like enviroments that support module.exports,
         // like Node.
         module.exports = factory(require('underscore'), require('backbone'), require('backbone.marionette'));
-    } else if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['underscore', 'backbone', 'backbone.marionette'], function (_, Backbone) {
+    } else if (typeof require === 'function' && typeof define === 'function' && define.amd) {
+        // AMD. Require witn an asynchronous callback to override default globally.
+        require(['underscore', 'backbone', 'backbone.marionette'], function (_, Backbone) {
             // Check if we use the AMD branch of Backbone
             _ = _ === undef ? root._ : _;
             Backbone = Backbone === undef ? root.Backbone : Backbone;

--- a/backbone.marionette.handlebars.min.js
+++ b/backbone.marionette.handlebars.min.js
@@ -1,6 +1,6 @@
 /*! Backbone.Marionette.Handlebars - v0.2.0
 ------------------------------
-Build @ 2012-07-24
+Build @ 2012-09-13
 Documentation and Full License Available at:
 http://asciidisco.github.com/Backbone.Marionette.Handlebars/index.html
 git://github.com/asciidisco/Backbone.Marionette.Handlebars.git
@@ -23,4 +23,4 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.*/
-(function(a,b,c,d,e,f,g){"use strict",typeof d=="object"?e.exports=f(c("underscore"),c("backbone"),c("backbone.marionette")):typeof b=="function"&&b.amd?b(["underscore","backbone","backbone.marionette"],function(b,c){return b=b===g?a._:b,c=c===g?a.Backbone:c,a.returnExportsGlobal=f(b,c,a)}):a.returnExportsGlobal=f(a._,a.Backbone)})(this,this.define,this.require,this.exports,this.module,function(a,b,c,d){"use strict";var e;return e=b.Marionette.Renderer.render,b.Marionette.Renderer.render=function(b,c){return a.isObject(b)&&b.type==="handlebars"?b.template(a.extend(c,b.data),b.options):e(b,c)},b.Marionette});
+(function(e,t,n,r,i,s,o){"use strict";typeof r=="object"?i.exports=s(n("underscore"),n("backbone"),n("backbone.marionette")):typeof n=="function"&&typeof t=="function"&&t.amd?n(["underscore","backbone","backbone.marionette"],function(t,n){return t=t===o?e._:t,n=n===o?e.Backbone:n,e.returnExportsGlobal=s(t,n,e)}):e.returnExportsGlobal=s(e._,e.Backbone)})(this,this.define,this.require,this.exports,this.module,function(e,t,n,r){"use strict";var i;return i=t.Marionette.Renderer.render,t.Marionette.Renderer.render=function(t,n){return e.isObject(t)&&t.type==="handlebars"?t.template(e.extend(n,t.data),t.options):i(t,n)},t.Marionette});


### PR DESCRIPTION
I don't know how controversial this change would be, but I find it slightly dissatisfying having to write

``` javascript
define([
    'backbone.marionette',
    'backbone/backbone.marionette.handlebars',          
    'hbs!Template/category',       
],
    function (Marionette, MarionetteHandlebars, categoryTpl) {
         ...
```

In all of my views just so that this plugin would kick in. I tried defining it in _deps_ config of requirejs, but it won't work, since the module has to be loaded effectively twice: once for the initializer to be injected, which replaces itself with a new anonymous module, and then again two activate the module. For this reason I propose changing the "define a new module" approach taken by the plugin to a "require" call instead. This will allow the plugin to be defined only once in _deps_ config of require.
