### PR TITLE
Bump underscore dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "grunt": ">=0.3.9"
    },
   "dependencies": {
-    "underscore"  : "~1.3.1",
+    "underscore"  : ">=1.3.1",
     "backbone": "0.9.x" 
   }
 }


### PR DESCRIPTION
Backbone 0.9.x happily works with underscore 1.4.x. There are some minor backwards incompatibilities in 1.4.0 & 1.4.1, but nothing that should impact B.M.H.

I see you're also the owner of this package on [jam](http://jamjs.org). If you could update this there, also, it'd be much appreciated. At the moment we have to roll our own version of this package with this one small change.
